### PR TITLE
Refactor NinjaController to use DTOs and add NinjaMapper

### DIFF
--- a/src/main/java/br/com/samueloliveira/CadastroDeNinjas/ninjas/NinjaController.java
+++ b/src/main/java/br/com/samueloliveira/CadastroDeNinjas/ninjas/NinjaController.java
@@ -1,5 +1,6 @@
 package br.com.samueloliveira.CadastroDeNinjas.ninjas;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -13,28 +14,32 @@ public class NinjaController {
         this.service = service;
     }
 
-    @GetMapping("/teste")
-    public String teste(){
-        return "Teste ok";
-    }
-
     @PostMapping("/create")
-    public List<NinjaModel> createNinja(NinjaModel ninja) {
-        return service.createNinja(ninja);
+    public NinjaResponseDTO createNinja(@RequestBody RegisterNinjaRequest request) {
+        return service.createNinja(request);
     }
 
-    @GetMapping("/all")
-    public List<NinjaModel> listNinjas() {
+    @GetMapping("/list")
+    public List<NinjaResponseDTO> listNinjas() {
         return service.listNinjas();
     }
 
-    @PutMapping("/update")
-    public List<NinjaModel> updateNinja(NinjaModel ninja) {
-        return service.updateNinja(ninja);
+    @GetMapping("/list/{id}")
+    public ResponseEntity<NinjaResponseDTO> findNinjaById(@PathVariable Long id) {
+        NinjaResponseDTO ninja = service.listNinjaById(id);
+
+        return ResponseEntity.ok(ninja);
     }
 
-    @DeleteMapping("{id}")
-    public List<NinjaModel> deleteNinja(@PathVariable("id") Long id) {
-        return service.deleteNinja(id);
+    @PutMapping("/update/{id}")
+    public NinjaResponseDTO updateNinja( @PathVariable Long id, @RequestBody RegisterNinjaRequest ninja) {
+        return service.updateNinja(id, ninja);
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<List<NinjaResponseDTO>> deleteNinja(@PathVariable Long id) {
+        List<NinjaResponseDTO> ninja = service.deleteNinja(id);
+
+        return ResponseEntity.ok(ninja);
     }
 }

--- a/src/main/java/br/com/samueloliveira/CadastroDeNinjas/ninjas/NinjaDTO.java
+++ b/src/main/java/br/com/samueloliveira/CadastroDeNinjas/ninjas/NinjaDTO.java
@@ -1,0 +1,6 @@
+package br.com.samueloliveira.CadastroDeNinjas.ninjas;
+
+import br.com.samueloliveira.CadastroDeNinjas.missoes.MissionModel;
+
+public record NinjaDTO(Long id, String nome, int idade, String email, String level, MissionModel missao) {
+}

--- a/src/main/java/br/com/samueloliveira/CadastroDeNinjas/ninjas/NinjaDTO.java
+++ b/src/main/java/br/com/samueloliveira/CadastroDeNinjas/ninjas/NinjaDTO.java
@@ -1,0 +1,4 @@
+package br.com.samueloliveira.CadastroDeNinjas.ninjas;
+
+public record NinjaDTO(){
+}

--- a/src/main/java/br/com/samueloliveira/CadastroDeNinjas/ninjas/NinjaMapper.java
+++ b/src/main/java/br/com/samueloliveira/CadastroDeNinjas/ninjas/NinjaMapper.java
@@ -1,0 +1,36 @@
+package br.com.samueloliveira.CadastroDeNinjas.ninjas;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class NinjaMapper {
+    private NinjaMapper(){}
+
+    /**
+     * Maps ninja model to response DTO
+     */
+    public NinjaResponseDTO toDTO(NinjaModel ninjaModel) {
+        return new NinjaResponseDTO(
+                ninjaModel.getId(),
+                ninjaModel.getNome(),
+                ninjaModel.getIdade(),
+                ninjaModel.getEmail(),
+                ninjaModel.getLevel(),
+                ninjaModel.getMissao()
+        );
+    }
+
+    /**
+     * Maps registration request to new ninja model
+     */
+    public NinjaModel toEntity(RegisterNinjaRequest request) {
+        var ninjaModel = new NinjaModel();
+        ninjaModel.setNome(request.nome());
+        ninjaModel.setIdade(request.idade());
+        ninjaModel.setEmail(request.email());
+        ninjaModel.setLevel(request.level());
+        ninjaModel.setMissao(request.missao());
+
+        return ninjaModel;
+    }
+}

--- a/src/main/java/br/com/samueloliveira/CadastroDeNinjas/ninjas/NinjaMapper.java
+++ b/src/main/java/br/com/samueloliveira/CadastroDeNinjas/ninjas/NinjaMapper.java
@@ -1,0 +1,4 @@
+package br.com.samueloliveira.CadastroDeNinjas.ninjas;
+
+public record NinjaMapper() {
+}

--- a/src/main/java/br/com/samueloliveira/CadastroDeNinjas/ninjas/NinjaResponseDTO.java
+++ b/src/main/java/br/com/samueloliveira/CadastroDeNinjas/ninjas/NinjaResponseDTO.java
@@ -1,0 +1,6 @@
+package br.com.samueloliveira.CadastroDeNinjas.ninjas;
+
+import br.com.samueloliveira.CadastroDeNinjas.missoes.MissionModel;
+
+public record NinjaResponseDTO(Long id, String nome, int idade, String email, String level, MissionModel missao) {
+}

--- a/src/main/java/br/com/samueloliveira/CadastroDeNinjas/ninjas/RegisterNinjaRequest.java
+++ b/src/main/java/br/com/samueloliveira/CadastroDeNinjas/ninjas/RegisterNinjaRequest.java
@@ -2,5 +2,5 @@ package br.com.samueloliveira.CadastroDeNinjas.ninjas;
 
 import br.com.samueloliveira.CadastroDeNinjas.missoes.MissionModel;
 
-public record NinjaDTO(Long id, String nome, int idade, String email, String level, MissionModel missao) {
+public record RegisterNinjaRequest(String nome, int idade, String email, String level, MissionModel missao){
 }


### PR DESCRIPTION
## Changes proposed in this PR

- Implementation of NinjaMapper, responsible for converting between NinjaModel, NinjaResponseDTO, and RegisterNinjaRequest.
- Creation of RegisterNinjaRequest, containing only the fields required for external communication and entity construction.
- Creation of NinjaResponseDTO, defining the data exposed by the API to consumers.
- Refactoring of NinjaController to work exclusively with DTOs, reducing direct coupling with the domain entity.

## Benefits

These changes strengthen the separation of concerns, improve code organization, and make the application more maintainable and ready for future evolution, especially in scenarios involving validation, API versioning, and domain model changes.